### PR TITLE
Add tests. Fix test by not reading values by identifier prematurely.

### DIFF
--- a/Assets/_Scripts/Tweedle/Editor/Tests/TweedleClassTest.cs
+++ b/Assets/_Scripts/Tweedle/Editor/Tests/TweedleClassTest.cs
@@ -35,6 +35,9 @@ namespace Alice.Tweedle.Parse
             + "  WholeNumber optionalOrDefaultMoreVariable(WholeNumber n <- x) {\n"
             + "    return n + x;\n"
             + "  }\n"
+            + "  WholeNumber optionalOrDefaultEarlierVariable(WholeNumber a, WholeNumber n <- a) {\n"
+            + "    return n + a;\n"
+            + "  }\n"
             + "  WholeNumber requiredMore(WholeNumber n) {\n"
             + "    return n + x;\n"
             + "  }\n"
@@ -560,6 +563,26 @@ namespace Alice.Tweedle.Parse
             TValue tested = scope.GetValue("val");
 
             Assert.AreEqual(6, tested.ToInt());
+        }
+
+        [Test]
+        public void MethodWithNamedOptionalArgumentShouldUsePassedArgmuent() {
+            Init();
+            ExecuteStatement("ClassToHave obj <- new ClassToHave(start: 4);");
+            ExecuteStatement("WholeNumber val  <- obj.optionalOrDefaultEarlierVariable(a: 9, n: 8);");
+            TValue tested = scope.GetValue("val");
+
+            Assert.AreEqual(17, tested.ToInt());
+        }
+
+        [Test]
+        public void MethodWithUnnamedOptionalArgumentShouldUseDefaultValueFromPreviousArgmuent() {
+            Init();
+            ExecuteStatement("ClassToHave obj <- new ClassToHave(start: 4);");
+            ExecuteStatement("WholeNumber val  <- obj.optionalOrDefaultEarlierVariable(a: 7);");
+            TValue tested = scope.GetValue("val");
+
+            Assert.AreEqual(14, tested.ToInt());
         }
 
         [Test]

--- a/Assets/_Scripts/Tweedle/Tweedle/Expression/IdentifierReference.cs
+++ b/Assets/_Scripts/Tweedle/Tweedle/Expression/IdentifierReference.cs
@@ -14,7 +14,7 @@ namespace Alice.Tweedle
 
         public override ExecutionStep AsStep(ExecutionScope scope)
         {
-            return new ValueStep("Get Identifier " + Name, scope, scope.GetValue(Name));
+            return new ValueGenerationStep("Get Value For Identifier " + Name, scope, () => scope.GetValue(Name));
         }
 
         public override string ToTweedle()


### PR DESCRIPTION
Wait to read until the step is executed, rather than when the step is created.