### PR TITLE
update ambient light color set function

### DIFF
--- a/Assets/_Scripts/Player/Modules/SceneGraph/SGGround.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/SGGround.cs
@@ -16,6 +16,8 @@ namespace Alice.Player.Unity {
             GetPropertyBlock(m_Renderer, ref m_PropertyBlock);
             m_PropertyBlock.SetVector("_MainTex_ST", new Vector4(100,100,0,0));
             m_Renderer.SetPropertyBlock(m_PropertyBlock);
+
+            m_ModelTransform.gameObject.layer = LayerMask.NameToLayer("Terrain");
         }
 
         protected override void CreateEntityCollider()

--- a/Assets/_Scripts/Player/Modules/SceneGraph/SGScene.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/SGScene.cs
@@ -32,6 +32,7 @@ namespace Alice.Player.Unity {
         private Light m_AboveLightA;
         private Light m_AboveLightB;
         private Light m_AboveLightC;
+        private Light m_AboveLightD;
         private const float k_AboveLightIntensity = 0.25f;
         private const float k_AboveLightPitch = 45f;
         private Light m_BelowLight;
@@ -61,8 +62,13 @@ namespace Alice.Player.Unity {
             base.Awake();
 
             m_AboveLightA = CreateLight(k_AboveLightPitch, 0f, k_AboveLightIntensity, true);
-            m_AboveLightB = CreateLight(k_AboveLightPitch, 120f, k_AboveLightIntensity, false);
-            m_AboveLightC = CreateLight(k_AboveLightPitch, 240f, k_AboveLightIntensity, false);
+            m_AboveLightB = CreateLight(k_AboveLightPitch, 120f, k_AboveLightIntensity, true);
+            m_AboveLightC = CreateLight(k_AboveLightPitch, 240f, k_AboveLightIntensity, true);
+            m_AboveLightD = CreateLight(90f, 0f, k_AboveLightIntensity, true);
+
+            m_AboveLightD.cullingMask &= ~(1 << LayerMask.NameToLayer("Terrain"));
+            Camera.main.cullingMask |= 1 << LayerMask.NameToLayer("Terrain");
+
 
             m_BelowLight = CreateLight(k_BelowLightPitch, 0, k_BelowLightIntensity, false);
 
@@ -266,7 +272,7 @@ namespace Alice.Player.Unity {
             m_GlobalBrightness = brightness;
             //RenderSettings.ambientIntensity = brightness;
             RenderSettings.reflectionIntensity = brightness;
-            m_AboveLightA.intensity = m_AboveLightB.intensity = m_AboveLightC.intensity = k_AboveLightIntensity * brightness;
+            m_AboveLightA.intensity = m_AboveLightB.intensity = m_AboveLightC.intensity = m_AboveLightD.intensity = k_AboveLightIntensity * brightness;
             m_BelowLight.intensity = k_BelowLightIntensity * brightness;
 
             UpdateAtmosphereColor();
@@ -275,7 +281,7 @@ namespace Alice.Player.Unity {
 
         private void OnUpdateAmbientLightColor(TValue inValue) {
             var color = inValue.RawObject<Primitives.Color>().Value;
-            m_AmbientLightColor = new UnityEngine.Color((float)color.R * 2, (float)color.G * 2, (float)color.B * 2, (float)color.A);
+            m_AmbientLightColor = new UnityEngine.Color((float)color.R, (float)color.G, (float)color.B, (float)color.A);
             UpdateAmbientLightColor();
         }
 
@@ -285,6 +291,7 @@ namespace Alice.Player.Unity {
             m_AboveLightA.color = unityColor;
             m_AboveLightB.color = unityColor;
             m_AboveLightC.color = unityColor;
+            m_AboveLightD.color = unityColor;
         }
 
         private void OnUpdateBelowLightColor(TValue inValue) {

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -14,7 +14,7 @@ TagManager:
   - 
   - 
   - VRUI
-  - 
+  - Terrain
   - 
   - 
   - 


### PR DESCRIPTION
In the Alice, the user could set atmosphere color, up light and below light. They are mapped into the Unity correctly.

There's a constant ambient light color in Alice, which is (0.25, 0.25, 0.25, 1). If the ambient light color in Unity is set as this value, the scene would look darker than it in Alice. So I change it into (0.5, 0.5, 0.5, 1)to make them look similar.