### PR TITLE
Lower fraction of pixels used to identify textures to treat as opaque…

### DIFF
--- a/Assets/_Scripts/Player/Modules/SceneGraph/SGJointedModel.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/SGJointedModel.cs
@@ -83,7 +83,7 @@ namespace Alice.Player.Unity {
 
         private static bool HasTranslucence(Texture2D texture) {
             const double epsilon = 0.01;
-            const double fractionOfAbsolutes = 0.96;
+            const double fractionOfAbsolutes = 0.84;
 
             var colors = texture.GetPixels();
             var total = colors.Length;


### PR DESCRIPTION
…. Corrects some models previously missed