### PR TITLE
Fix and consolidate file identifiers into WorldObjects

### DIFF
--- a/Assets/_Scripts/Player/UI/LoadMoreControl.cs
+++ b/Assets/_Scripts/Player/UI/LoadMoreControl.cs
@@ -5,7 +5,6 @@ using UnityEngine;
 using TMPro;
 using System.IO;
 using BeauRoutine;
-using System.Linq;
 using Alice.Tweedle.Parse;
 using UnityEngine.UI;
 
@@ -87,9 +86,9 @@ public class LoadMoreControl : MonoBehaviour
         recentWorldsData.Clear();
 
         var dir = new DirectoryInfo(UnityObjectParser.AutoLoadedWorldsDirectory);
-        var files = dir.GetFiles("*.a3w");
+        var files = dir.GetFiles(WorldObjects.ProjectPattern);
         foreach (var file in files) {
-            if (!File.Exists(file.FullName) || file.FullName.Contains(WorldObjects.SCENE_GRAPH_LIBRARY_NAME + ".a3w"))
+            if (!File.Exists(file.FullName) || file.FullName.Contains(WorldObjects.SceneGraphLibraryName))
                 continue;
             recentWorldsData.Add(new RecentWorldData(file.FullName));
         }

--- a/Assets/_Scripts/Player/UI/MenuControl.cs
+++ b/Assets/_Scripts/Player/UI/MenuControl.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using Alice.Tweedle.Parse;
 using SFB;
 using UnityEngine;
 using UnityEngine.UI;
@@ -68,7 +67,7 @@ public class MenuControl : MonoBehaviour
         loadNewWorldButton.onClick.AddListener(() =>
         {
             string zipPath = "";
-            var path = StandaloneFileBrowser.OpenFilePanel("Open File", "", UnityObjectParser.project_ext, false);
+            var path = StandaloneFileBrowser.OpenFilePanel("Open File", "", WorldObjects.ProjectExt, false);
             if(path.Length > 0) {
                 zipPath = path[0];
                 zipPath = System.Uri.UnescapeDataString(zipPath);

--- a/Assets/_Scripts/Player/WorldObjects.cs
+++ b/Assets/_Scripts/Player/WorldObjects.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 using Alice.Tweedle.Parse;
 
 public class WorldObjects : MonoBehaviour
@@ -11,9 +9,11 @@ public class WorldObjects : MonoBehaviour
     public GameObject vrObjects;
     public UnityObjectParser parser;
 
-    public static string SCENE_GRAPH_LIBRARY_NAME = "SceneGraphLibrary";
-    public static string DEFAULT_BUNDLED_WORLD_NAME = "DefaultBundledWorld";
-    public static string DEFAULT_FOLDER_PATH = "Default";
+    public static readonly string ProjectExt = "a3w";
+    public static readonly string ProjectPattern = $"*.{ProjectExt}";
+    public static readonly string SceneGraphLibraryName = $"SceneGraphLibrary.{ProjectExt}";
+    public static readonly string DefaultBundledWorldName = $"DefaultBundledWorld.{ProjectExt}";
+    public static readonly string DefaultFolderPath = "Default";
     
     private readonly WorldExecutionState _executionState = new WorldExecutionState();
     

--- a/Assets/_Scripts/Tweedle/Parse/JsonParser.cs
+++ b/Assets/_Scripts/Tweedle/Parse/JsonParser.cs
@@ -2,7 +2,6 @@ using System;
 using Alice.Tweedle.File;
 using Alice.Player.Unity;
 using ICSharpCode.SharpZipLib.Zip;
-using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 using System.Text;
@@ -97,7 +96,7 @@ namespace Alice.Tweedle.Parse
                 m_ZipFile = new ZipFile(m_FileStream);
 
                 using (m_ZipFile) {
-                    if(!m_FileName.Contains(WorldObjects.SCENE_GRAPH_LIBRARY_NAME))
+                    if(!m_FileName.Contains(WorldObjects.SceneGraphLibraryName))
                         CacheThumbnail(m_FileName);
 
                     // TODO: Use manifest to determine player assembly version
@@ -161,8 +160,8 @@ namespace Alice.Tweedle.Parse
                     else
                     {
                         var e = new TweedleVersionException("Could not find prerequisite " + t.name,
-                            WorldObjects.SCENE_GRAPH_LIBRARY_NAME + " " + PlayerLibraryManifest.Instance.GetLibraryVersion(),
-                            WorldObjects.SCENE_GRAPH_LIBRARY_NAME + " " + t.version,
+                            WorldObjects.SceneGraphLibraryName + " " + PlayerLibraryManifest.Instance.GetLibraryVersion(),
+                            WorldObjects.SceneGraphLibraryName + " " + t.version,
                             PlayerLibraryManifest.Instance.aliceVersion,
                             manifest.provenance.aliceVersion);
 

--- a/Assets/_Scripts/Tweedle/Parse/UnityObjectParser.cs
+++ b/Assets/_Scripts/Tweedle/Parse/UnityObjectParser.cs
@@ -11,7 +11,6 @@ namespace Alice.Tweedle.Parse
 {
     public class UnityObjectParser : MonoBehaviour
     {
-        public static string project_ext = "a3w";
         public static string AutoLoadedWorldsDirectory;
         public bool dumpTypeOutlines = false;
         public Transform mainMenu;
@@ -29,13 +28,14 @@ namespace Alice.Tweedle.Parse
         private VirtualMachine m_VM;
         private Routine m_QueueProcessor;
         private string m_currentFilePath;
+
         void Awake()
         {
 #if UNITY_ANDROID
             AutoLoadedWorldsDirectory = Application.persistentDataPath;
 #else
 #if UNITY_WEBGL
-            AutoLoadedWorldsDirectory = $"{Application.streamingAssetsPath}/{WorldObjects.DEFAULT_FOLDER_PATH}/{WorldObjects.DEFAULT_BUNDLED_WORLD_NAME}.{project_ext} ";
+            AutoLoadedWorldsDirectory = $"{Application.streamingAssetsPath}/{WorldObjects.DefaultFolderPath}/{WorldObjects.DefaultBundledWorldName}";
 #else
             AutoLoadedWorldsDirectory = Application.streamingAssetsPath;
 #endif
@@ -164,7 +164,7 @@ namespace Alice.Tweedle.Parse
             string[] args = System.Environment.GetCommandLineArgs();
 
             for(int i = 0; i < args.Length; i++) {
-                if(args[i].ToLower().Contains(project_ext)) {
+                if(args[i].ToLower().Contains(WorldObjects.ProjectExt)) {
                     loadingScreen.fader.alpha = 1f;
                     OpenWorld(args[1]);
                     return;
@@ -184,11 +184,11 @@ namespace Alice.Tweedle.Parse
 #if UNITY_WEBGL
             OpenWorldDirectly(AutoLoadedWorldsDirectory);
 #else
-            var files = new DirectoryInfo(AutoLoadedWorldsDirectory).GetFiles("*" + project_suffix);
+            var files = new DirectoryInfo(AutoLoadedWorldsDirectory).GetFiles(WorldObjects.ProjectPattern);
             var fileCount = files.Length;
 #if UNITY_IOS || UNITY_ANDROID
             if (fileCount == 0) {
-                OpenWorldDirectly(Path.Combine(Application.streamingAssetsPath, WorldObjects.DEFAULT_FOLDER_PATH, WorldObjects.DEFAULT_BUNDLED_WORLD_NAME + project_suffix));
+                OpenWorldDirectly(Path.Combine(Application.streamingAssetsPath, WorldObjects.DefaultFolderPath, WorldObjects.DefaultBundledWorldName));
             }
 #endif
             if (fileCount == 1) {


### PR DESCRIPTION
Missed a configuration. This should fix the build for all current platforms.