### PR TITLE
Fixes #512, #591

### DIFF
--- a/Assets/_Scripts/Player/Modules/SceneGraph/SGTextModel.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/SGTextModel.cs
@@ -5,7 +5,7 @@ using BeauRoutine;
 namespace Alice.Player.Unity {
     public sealed class SGTextModel : SGModel {
 
-        private string currTextStr = "";
+        [SerializeField]private string currTextStr = "";
         private GameObject textStrObj;
         private Renderer m_Renderer;
         private MeshFilter m_MeshFilter;
@@ -61,7 +61,8 @@ namespace Alice.Player.Unity {
         }
 
         private void OnTextPropertyChanged(TValue inValue) {
-            currTextStr = inValue.ToTextString();
+            // Unescapes any escaped characters in the input string 
+            currTextStr = System.Text.RegularExpressions.Regex.Unescape(inValue.ToTextString());
             RefreshText();
         }
     }

--- a/Assets/_Scripts/Player/Modules/SceneGraph/SGTextModel.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/SGTextModel.cs
@@ -5,7 +5,7 @@ using BeauRoutine;
 namespace Alice.Player.Unity {
     public sealed class SGTextModel : SGModel {
 
-        [SerializeField]private string currTextStr = "";
+        private string currTextStr = "";
         private GameObject textStrObj;
         private Renderer m_Renderer;
         private MeshFilter m_MeshFilter;

--- a/Assets/_Scripts/Player/Modules/SceneGraph/UI/SayThinkBubble.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/UI/SayThinkBubble.cs
@@ -54,6 +54,7 @@ namespace Alice.Player.Unity {
         }
 
         public void SetText(string text, UnityEngine.Color c, TMP_FontAsset font, float scale){
+            text = System.Text.RegularExpressions.Regex.Unescape(text);// Converts escape sequences in strings into the characters they represent
             bubbleText.text = text;
             bubbleText.color = c;
             bubbleText.font = font;

--- a/Assets/_Scripts/Player/Modules/SceneGraph/UI/SayThinkBubble.cs
+++ b/Assets/_Scripts/Player/Modules/SceneGraph/UI/SayThinkBubble.cs
@@ -54,8 +54,8 @@ namespace Alice.Player.Unity {
         }
 
         public void SetText(string text, UnityEngine.Color c, TMP_FontAsset font, float scale){
-            text = System.Text.RegularExpressions.Regex.Unescape(text);// Converts escape sequences in strings into the characters they represent
-            bubbleText.text = text;
+            // Converts escape sequences in strings into the characters they represent and assigns it to the bubble text
+            bubbleText.text = System.Text.RegularExpressions.Regex.Unescape(text);
             bubbleText.color = c;
             bubbleText.font = font;
             fontSizeUnscaled = BASE_FONT_SIZE * scale;


### PR DESCRIPTION
Fixed emoji displaying as unicode numbers and quote character showing with backslashes in speech bubbles.